### PR TITLE
Migrate from v0 to v1 in auth

### DIFF
--- a/fia_auth/auth.py
+++ b/fia_auth/auth.py
@@ -22,7 +22,7 @@ def authenticate(credentials: UserCredentials) -> User:
     data = {"username": credentials.username, "password": credentials.password}
     logger.info(f"Authentication user: {credentials.username[0:3]}*****")  # Partial reveal to help logging
     response = requests.post(
-        f"{UOWS_URL}/v0/sessions",
+        f"{UOWS_URL}/v1/sessions",
         json=data,
         headers={"Content-Type": "application/json"},
         timeout=30,

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -21,7 +21,7 @@ def test_authenticate_success(mock_post):
     assert user.user_number == "12345"
 
     mock_post.assert_called_once_with(
-        "https://devapi.facilities.rl.ac.uk/users-service/v0/sessions",
+        "https://devapi.facilities.rl.ac.uk/users-service/v1/sessions",
         json={"username": "valid_user", "password": "valid_password"},
         headers={"Content-Type": "application/json"},
         timeout=30,


### PR DESCRIPTION
Closes None, is needed to avoid license issues.

## Description
Just moves from v0 to v1 for UOWS API