### PR TITLE
Fix auth bug

### DIFF
--- a/fia_auth/auth.py
+++ b/fia_auth/auth.py
@@ -31,13 +31,16 @@ def authenticate(credentials: UserCredentials) -> User:
         logger.info("Session created with UOWS")
         user_id = response.json()["userId"]
         uows_api_key = os.environ.get("UOWS_API_KEY", "")
-        details_response = requests.post(
+        details_response = requests.get(
             f"{UOWS_URL}/v1/basic-person-details?userNumbers={user_id}",
-            json=data,
             headers={"Authorization": f"Api-key {uows_api_key}", "Content-Type": "application/json"},
             timeout=30,
         )
-        return User(user_number=user_id, username=details_response.json()["displayName"])
+        if (details_response.status_code != HTTPStatus.OK or len(details_response.json()) < 1
+                or "displayName" not in details_response.json()[0]):
+            logger.warning("Unexpected error occured when authentication with the UOWS: %s", response.text)
+            raise UOWSError("An unexpected error occurred when authenticating with the user office web service")
+        return User(user_number=user_id, username=details_response.json()[0]["displayName"])
     if response.status_code == HTTPStatus.UNAUTHORIZED:
         logger.info("Bad credentials given to UOWS")
         raise BadCredentialsError("Invalid user credentials provided to authenticate with the user office web service.")

--- a/fia_auth/auth.py
+++ b/fia_auth/auth.py
@@ -36,8 +36,11 @@ def authenticate(credentials: UserCredentials) -> User:
             headers={"Authorization": f"Api-key {uows_api_key}", "Content-Type": "application/json"},
             timeout=30,
         )
-        if (details_response.status_code != HTTPStatus.OK or len(details_response.json()) < 1
-                or "displayName" not in details_response.json()[0]):
+        if (
+            details_response.status_code != HTTPStatus.OK
+            or len(details_response.json()) < 1
+            or "displayName" not in details_response.json()[0]
+        ):
             logger.warning("Unexpected error occured when authentication with the UOWS: %s", response.text)
             raise UOWSError("An unexpected error occurred when authenticating with the user office web service")
         return User(user_number=user_id, username=details_response.json()[0]["displayName"])

--- a/test/e2e/test_auth.py
+++ b/test/e2e/test_auth.py
@@ -16,10 +16,14 @@ client = TestClient(app)
 @patch("fia_auth.model.is_instrument_scientist")
 @patch("fia_auth.auth.requests")
 def test_successful_login(mock_auth_requests, is_instrument_scientist):
-    mock_auth_response = Mock()
-    mock_auth_response.status_code = HTTPStatus.CREATED
-    mock_auth_response.json.return_value = {"userId": 1234, "displayName": "Mr Cool"}
-    mock_auth_requests.post.return_value = mock_auth_response
+    mock_post_auth_response = Mock()
+    mock_post_auth_response.status_code = HTTPStatus.CREATED
+    mock_post_auth_response.json.return_value = {"userId": 1234, "displayName": "Mr Cool"}
+    mock_get_auth_response = Mock()
+    mock_get_auth_response.status_code = HTTPStatus.OK
+    mock_get_auth_response.json.return_value = [{"displayName": "Mr Cool"}]
+    mock_auth_requests.post.return_value = mock_post_auth_response
+    mock_auth_requests.get.return_value = mock_get_auth_response
     is_instrument_scientist.return_value = False
 
     response = client.post("/api/jwt/authenticate", json={"username": "foo", "password": "foo"})

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -11,12 +11,14 @@ from fia_auth.exceptions import BadCredentialsError, UOWSError
 from fia_auth.model import UserCredentials
 
 
+@patch("requests.get")
 @patch("requests.post")
-def test_authenticate_success(mock_post):
+def test_authenticate_success(mock_post, mock_get):
     uows_api_key = str(mock.MagicMock())
     os.environ["UOWS_API_KEY"] = uows_api_key
     mock_response = Mock(status_code=HTTPStatus.CREATED, json=lambda: {"userId": "12345", "displayName": "Mr Cool"})
     mock_post.return_value = mock_response
+    mock_get.return_value = mock_response
 
     credentials = UserCredentials(username="valid_user", password="valid_password")  # noqa: S106
 

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -2,7 +2,7 @@
 import os
 from http import HTTPStatus
 from unittest import mock
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -16,7 +16,9 @@ from fia_auth.model import UserCredentials
 def test_authenticate_success(mock_post, mock_get):
     uows_api_key = str(mock.MagicMock())
     os.environ["UOWS_API_KEY"] = uows_api_key
-    mock_post_response = Mock(status_code=HTTPStatus.CREATED, json=lambda: {"userId": "12345", "displayName": "Mr Cool"})
+    mock_post_response = Mock(
+        status_code=HTTPStatus.CREATED, json=lambda: {"userId": "12345", "displayName": "Mr Cool"}
+    )
     mock_get_response = Mock(status_code=HTTPStatus.OK, json=lambda: [{"displayName": "Mr Cool"}])
     mock_post.return_value = mock_post_response
     mock_get.return_value = mock_get_response
@@ -28,13 +30,17 @@ def test_authenticate_success(mock_post, mock_get):
     assert user.user_number == "12345"
     assert user.username == "Mr Cool"
 
-    mock_post.assert_called_once_with(            "https://devapi.facilities.rl.ac.uk/users-service/v1/sessions",
-            json={"username": "valid_user", "password": "valid_password"},
-            headers={"Content-Type": "application/json"},
-            timeout=30,)
-    mock_get.assert_called_once_with("https://devapi.facilities.rl.ac.uk/users-service/v1/basic-person-details?userNumbers=12345",
-            headers={"Authorization": f"Api-key {uows_api_key}", "Content-Type": "application/json"},
-            timeout=30,)
+    mock_post.assert_called_once_with(
+        "https://devapi.facilities.rl.ac.uk/users-service/v1/sessions",
+        json={"username": "valid_user", "password": "valid_password"},
+        headers={"Content-Type": "application/json"},
+        timeout=30,
+    )
+    mock_get.assert_called_once_with(
+        "https://devapi.facilities.rl.ac.uk/users-service/v1/basic-person-details?userNumbers=12345",
+        headers={"Authorization": f"Api-key {uows_api_key}", "Content-Type": "application/json"},
+        timeout=30,
+    )
 
 
 @patch("requests.post")


### PR DESCRIPTION
Closes None, issue was noticed in staging

## Description
Display name didn't exist due to an issue with what we are calling (Called with post instead of get), and then it failed to return correctly, so some error handling has been added.