### PR TITLE
Revert "Bump python from 3.12-slim to 3.13-slim in /container in the docker group"

### DIFF
--- a/container/fia-auth.Dockerfile
+++ b/container/fia-auth.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.12-slim
 
 WORKDIR /fia_auth
 


### PR DESCRIPTION
Reverts fiaisis/fia-auth#97